### PR TITLE
feat: add pre-flight app symlink check to docker-compose passthrough

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,18 +1,11 @@
 # Butler TODO
 
-- Improve composer command to check if composer.phar exists, if so use that, otherwise check composer if not
-  return 1 "composer.phar or composer does not exist on container"
-- Add config for keyfile
-- Check if there is an option on docker compose to not create directories for mounts if they don't exist
-    and instead fail out
 - REWRITE: Sail literally everything is a docker-compose command. Because I want
 to be able to call without the site name from the project directory this should be the default
 therefore `butler up jamgolf` no longer is possible we should instead by default
 assume we are in the project directory otherwise this can be overriden by --site
 THEN we can assume all other arguments are being sent to docker compose
-- Add site config, for example for domain
 - Add command to auto link all sites
-- use that thing that automatically creates hostfile entries
 - add ability to use in project docker compose as well - fall back to docker-composer commands like the laravel one?
 - Look at laravels one as it might help tidy up the code
 - Add --site to docker-compose exec passthrough
@@ -24,7 +17,6 @@ THEN we can assume all other arguments are being sent to docker compose
     We should probably prefix the env vars when we export them so that they don't clash
     We can then move that exporting to a new common bin and execute that before running the make file
     We can exit with an error if the env file does not exist, or run a setup
-- need a domain config as if the site and project dir are different it doesn't work
 - auto create networks
 - I wonder if there could be some kinda watcher on domains so if you
   browse to example.local and a site exists for that domain it boots it

--- a/bin/common/functions.sh
+++ b/bin/common/functions.sh
@@ -56,6 +56,38 @@ write_butler_projects() {
   fi
 }
 
+app_link_status() {
+  local link_path="$1"
+  if [ -L "$link_path" ] && [ -e "$link_path" ]; then
+    echo "ok"
+  elif [ -L "$link_path" ]; then
+    echo "broken"
+  else
+    echo "missing"
+  fi
+}
+
+assert_app_linked() {
+  local site_dir="$1" site="$2" butler_projects="$3"
+  local app_path="$site_dir/app"
+
+  if [ -n "$butler_projects" ]; then
+    local p status fix
+    for p in ${butler_projects//,/ }; do
+      status="$(app_link_status "$app_path/$p")"
+      [ "$status" = "ok" ] && continue
+      fix="$([ "$status" = "broken" ] && echo "--fix ")"
+      die_with_error "Project symlink ${CWarn}$p${Color_Off} is $status. Run: butler site link ${fix}$site"
+    done
+  else
+    local status fix
+    status="$(app_link_status "$app_path")"
+    [ "$status" = "ok" ] && return 0
+    fix="$([ "$status" = "broken" ] && echo "--fix ")"
+    die_with_error "app symlink is $status. Run: butler site link ${fix}$site"
+  fi
+}
+
 die_with_error() {
   echo -e "${CError}Error:${Color_Off} $*" >&2
   exit 1

--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -26,6 +26,11 @@ cd "$BIN_DIR" || exit
 docker ps | grep -q nginx-proxy || docker compose \
   --project-directory "$ROOT_DIR/common/nginx-proxy" up -d
 
+# Ensure app symlink(s) are valid before attempting compose commands
+BUTLER_PROJECTS=""
+[ -f "$CURRENT_SITE_DIR/.env" ] && . "$CURRENT_SITE_DIR/.env"
+assert_app_linked "$CURRENT_SITE_DIR" "$CURRENT_SITE" "$BUTLER_PROJECTS"
+
 # Run any site scripts
 if [ -f "$CURRENT_SITE_DIR/scripts/$cmd" ]; then
   # shellcheck source=/dev/null

--- a/bin/site-link
+++ b/bin/site-link
@@ -20,14 +20,16 @@ print_usage() {
 link_single() {
   local site="$1" site_dir="$2" project_path="$3" fix="$4"
   local app_path="$site_dir/app"
+  local status
+  status="$(app_link_status "$app_path")"
 
-  if [ -L "$app_path" ] && [ -e "$app_path" ]; then
+  if [ "$status" = "ok" ]; then
     statusBadge "$site" "SKIP" "$CWarn" "already linked"
     return 0
   fi
 
   local fixed=false
-  if [ -L "$app_path" ] && [ ! -e "$app_path" ]; then
+  if [ "$status" = "broken" ]; then
     if $fix; then
       fixed=true
       rm "$app_path"
@@ -70,9 +72,11 @@ link_multi() {
       continue
     fi
 
-    if [ -L "$proj_link" ] && [ -e "$proj_link" ]; then
+    local proj_status
+    proj_status="$(app_link_status "$proj_link")"
+    if [ "$proj_status" = "ok" ]; then
       statusBadge "$p" "SKIP" "$CWarn" "already linked"
-    elif [ -L "$proj_link" ] && [ ! -e "$proj_link" ]; then
+    elif [ "$proj_status" = "broken" ]; then
       if $fix; then
         rm "$proj_link"
         ln -s "$proj_path" "$proj_link"

--- a/bin/site-status
+++ b/bin/site-status
@@ -17,17 +17,6 @@ print_usage() {
   echo "  -v, --verbose       print site directory"
 }
 
-app_link_status() {
-  local link_path="$1"
-  if [ -L "$link_path" ] && [ -e "$link_path" ]; then
-    echo "ok"
-  elif [ -L "$link_path" ]; then
-    echo "broken"
-  else
-    echo "missing"
-  fi
-}
-
 status_single() {
   local site="$1" site_dir="$2" verbose="$3"
   local app_path="$site_dir/app"


### PR DESCRIPTION
- Fails early with a repair hint if the app symlink is broken or missing before invoking docker compose. 
- Extracts shared symlink status logic into common so site-status, site-link, and docker-compose all use it.