### PR TITLE
feat: add butler templates command

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ If `SITE` is omitted from site commands, butler infers the site from your curren
 
 | Command | Description |
 | --- | --- |
+| `butler templates` | List available site templates |
 | `butler mysql` | Open a MySQL shell |
 | `butler ftp` | Run an ephemeral FTP server |
 | `butler sftp` | Run an ephemeral SFTP server |

--- a/bin/templates
+++ b/bin/templates
@@ -1,0 +1,21 @@
+#!/bin/bash
+# templates subcommand — list available site templates
+
+print_usage() {
+  echo "List available site templates"
+  echo " "
+  echo "SYNOPSIS:"
+  echo " "
+  echo "butler templates"
+}
+
+main() {
+  [ "$1" = "-h" ] || [ "$1" = "--help" ] && print_usage && exit 0
+
+  for t in "$ROOT_DIR/templates"/*/; do
+    [ -d "$t" ] || continue
+    echo -e "  ${Green}$(basename "$t")${Color_Off}"
+  done
+}
+
+main "$@"

--- a/butler
+++ b/butler
@@ -51,6 +51,7 @@ print_usage() {
   echo -e "${Yellow}Other Commands:"
   echo -e ""
   echo -e "${Green}dns                  ${Color_Off}Manage automatic DNS resolution"
+  echo -e "${Green}templates            ${Color_Off}List available site templates"
   echo -e "${Green}ftp                  ${Color_Off}Run ftp server"
   echo -e "${Green}sftp                 ${Color_Off}Run sftp server"
   echo -e "${Green}mysql                ${Color_Off}Run mysql shell"
@@ -70,7 +71,7 @@ export HOST_GID
 
 # Non-site-aware commands skip site resolution; everything else resolves
 case $function in
-site | ftp | sftp | mysql | dns) ;;
+site | ftp | sftp | mysql | dns | templates) ;;
 *) resolve_site "$1" && shift ;;
 esac
 
@@ -99,6 +100,7 @@ case $function in
 
 # Other
 'dns') . "$BIN_DIR/dns" && main "$@" ;;
+'templates') . "$BIN_DIR/templates" "$@" ;;
 'ftp') . "$BIN_DIR/ftp" "$@" ;;
 'sftp') . "$BIN_DIR/sftp" "$@" ;;
 'mysql') . "$BIN_DIR/mysql" "$@" ;;

--- a/tests/unit/templates.bats
+++ b/tests/unit/templates.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+load "../helpers/common"
+
+setup_extra() {
+  . "$BIN_DIR/templates"
+}
+
+@test "templates lists known templates" {
+  run main
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "wordpress"
+  echo "$output" | grep -q "php8.3"
+}
+
+@test "templates -h exits 0" {
+  run main -h
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

- `butler templates` lists all available site templates from the `templates/` directory
- Listed in green, one per line
- Supports `-h`/`--help`
- Added to top-level usage and README