### PR TITLE
feat: add butler site list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ If `SITE` is omitted from site commands, butler infers the site from your curren
 | --- | --- |
 | `butler install` | First-time setup wizard |
 | `butler site add` | Add a new site |
+| `butler site list` | List all sites |
 | `butler site add --multi` | Add a new multi-project site |
 | `butler site convert [SITE]` | Convert single-project site to multi-project |
 | `butler site cd` | Change directory to a site |

--- a/bin/site
+++ b/bin/site
@@ -13,6 +13,7 @@ print_usage() {
   echo -e "${Yellow}Site Management:"
   echo -e ""
   echo -e "${Green}add     ${Color_Off}Add a new site"
+  echo -e "${Green}list    ${Color_Off}List all sites"
   echo -e "${Green}cd      ${Color_Off}Change directory to site"
   echo -e "${Green}convert ${Color_Off}Convert single-project site to multi-project"
   echo -e "${Green}status  ${Color_Off}Show status of site(s)"
@@ -26,6 +27,7 @@ shift
 
 case $function in
 'add') . "$BIN_DIR/site-add" && main "$@" ;;
+'list') . "$BIN_DIR/site-list" && main "$@" ;;
 'cd') "$BIN_DIR/site-cd" "$@" ;;
 'convert') . "$BIN_DIR/site-convert" && main "$@" ;;
 'status') . "$BIN_DIR/site-status" && main "$@" ;;

--- a/bin/site-list
+++ b/bin/site-list
@@ -1,0 +1,29 @@
+#!/bin/bash
+# site list subcommand — list all sites
+
+PACKAGE="butler site list"
+
+print_usage() {
+  echo "List all sites"
+  echo " "
+  echo "SYNOPSIS:"
+  echo " "
+  echo "$PACKAGE"
+}
+
+main() {
+  [ "$1" = "-h" ] || [ "$1" = "--help" ] && print_usage && exit 0
+
+  local found=false
+  local site_dir
+
+  for site_dir in "$SITES_DIR"/*/; do
+    [ -d "$site_dir" ] || continue
+    echo -e "  ${Green}$(basename "$site_dir")${Color_Off}"
+    found=true
+  done
+
+  if ! $found; then
+    echo "No sites found in $SITES_DIR"
+  fi
+}

--- a/butler
+++ b/butler
@@ -29,6 +29,7 @@ print_usage() {
   echo -e "${Yellow}Site Management:"
   echo -e ""
   echo -e "${Green}site add             ${Color_Off}Add a new site"
+  echo -e "${Green}site list            ${Color_Off}List all sites"
   echo -e "${Green}site cd              ${Color_Off}Change directory to site"
   echo -e "${Green}site convert         ${Color_Off}Convert single-project site to multi-project"
   echo -e "${Green}site status          ${Color_Off}Show status of site(s)"

--- a/tests/unit/site-list.bats
+++ b/tests/unit/site-list.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+load "../helpers/common"
+
+setup_extra() {
+  . "$BIN_DIR/site-list"
+}
+
+@test "site list shows all sites" {
+  mkdir -p "$SITES_DIR/alpha" "$SITES_DIR/beta"
+
+  run main
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "alpha"
+  echo "$output" | grep -q "beta"
+}
+
+@test "site list prints message when no sites exist" {
+  run main
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "No sites found"
+}
+
+@test "site list -h exits 0" {
+  run main -h
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

- `butler site list` lists all sites in `SITES_DIR`, one per line in green
- Shows "No sites found" when `SITES_DIR` is empty
- Added to `butler site` dispatcher, top-level usage, and README
- 3 tests; all 84 pass