### PR TITLE
fix(templates): add --allow-unauthenticated for Stretch templates

### DIFF
--- a/templates/php7.1-nginx/PHP.DockerFile
+++ b/templates/php7.1-nginx/PHP.DockerFile
@@ -6,7 +6,7 @@ RUN ln -s /run/secrets/user_ssh /home/user/.ssh
 RUN sed -i -e 's/deb.debian.org/archive.debian.org/g' \
            -e 's|security.debian.org|archive.debian.org/|g' \
            -e '/stretch-updates/d' /etc/apt/sources.list
-RUN apt-get update -y && apt-get install -y libpng-dev libicu-dev libxml2-dev
+RUN apt-get update -y && apt-get install -y --allow-unauthenticated libpng-dev libicu-dev libxml2-dev
 
 RUN docker-php-ext-install gd intl json mbstring \
     pdo_mysql opcache xml zip


### PR DESCRIPTION
## Summary

- `php7.1-nginx` template was missing `--allow-unauthenticated` on its `apt-get install` — Debian Stretch is EOL and its GPG keys have expired, so apt refuses to install without this flag
- `commerce-5.6` already had this fix; `php7.1-nginx` was the only remaining gap