### PR TITLE
fix(site-clone): respect BUTLER_REQUIRED_CONTEXT and -c flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If `SITE` is omitted from site commands, butler infers the site from your curren
 | `butler install` | First-time setup wizard |
 | `butler site add` | Add a new site |
 | `butler site list` | List all sites |
-| `butler site clone [SITE] <REPO>` | Clone a repo and link it to an existing site |
+| `butler site clone [-c CONTEXT] [SITE] <REPO>` | Clone a repo and link it to an existing site |
 | `butler site add --multi` | Add a new multi-project site |
 | `butler site convert [SITE]` | Convert single-project site to multi-project |
 | `butler site cd` | Change directory to a site |

--- a/bin/site-clone
+++ b/bin/site-clone
@@ -15,12 +15,14 @@ print_usage() {
   echo "$PACKAGE [SITE] [REPO]"
   echo " "
   echo "  -h, --help         print this help"
+  echo "  -c, --context      project context subdirectory (e.g. personal)"
   echo " "
   echo "SITE and REPO are prompted interactively if not provided."
 }
 
 main() {
   help=false
+  context=''
   local args=()
 
   while [[ $# -gt 0 ]]; do
@@ -28,6 +30,10 @@ main() {
     -h | --help)
       help=true
       shift
+      ;;
+    -c | --context)
+      context="$2"
+      shift 2
       ;;
     --)
       shift
@@ -63,6 +69,9 @@ main() {
     die_with_error "Multi-project sites are not yet supported by this command"
   fi
 
+  $BUTLER_REQUIRED_CONTEXT && [ -z "$context" ] && read -rp "Specify a context: " context
+  [[ ! "$context" =~ ^[[:alpha:]]*$ ]] && die_with_error "Context must be alphabetic"
+
   [ -z "$repo" ] && read -r -p "Repository URL: " repo
   [ -z "$repo" ] && die_with_error "No repository specified"
 
@@ -71,7 +80,9 @@ main() {
     die_with_error "Cannot reach repository: $repo"
   fi
 
-  local proj_dir="$CURRENT_PROJ_DIR"
+  local proj_dir="$PROJECTS_DIR"
+  [ -n "$context" ] && proj_dir="$proj_dir/$context"
+  proj_dir="$proj_dir/$BUTLER_PROJECT"
 
   confirm_existing_project_dir "$proj_dir" || exit 0
 

--- a/tests/unit/site-clone.bats
+++ b/tests/unit/site-clone.bats
@@ -56,3 +56,43 @@ setup_extra() {
   [ "$status" -eq 0 ]
   echo "$output" | grep -qi "skip"
 }
+
+@test "main clones into context subdir when -c given" {
+  local site_dir repo_dir
+  site_dir="$SITES_DIR/mysite"
+  mkdir -p "$site_dir"
+
+  repo_dir="$(mktemp -d)"
+  git init --bare "$repo_dir" >/dev/null 2>&1
+
+  run main -c personal mysite "$repo_dir"
+  [ "$status" -eq 0 ]
+  [ -L "$site_dir/app" ]
+  [ -d "$PROJECTS_DIR/personal/mysite/.git" ]
+}
+
+@test "main exits 1 when context is non-alphabetic" {
+  local site_dir repo_dir
+  site_dir="$SITES_DIR/mysite"
+  mkdir -p "$site_dir"
+
+  repo_dir="$(mktemp -d)"
+  git init --bare "$repo_dir" >/dev/null 2>&1
+
+  run main -c "bad-context" mysite "$repo_dir"
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -qi "alphabetic"
+}
+
+@test "main clones to root PROJECTS_DIR when no context given" {
+  local site_dir repo_dir
+  site_dir="$SITES_DIR/mysite"
+  mkdir -p "$site_dir"
+
+  repo_dir="$(mktemp -d)"
+  git init --bare "$repo_dir" >/dev/null 2>&1
+
+  run main mysite "$repo_dir"
+  [ "$status" -eq 0 ]
+  [ -d "$PROJECTS_DIR/mysite/.git" ]
+}


### PR DESCRIPTION
## Summary

- `site clone` was ignoring context — `init_site` builds `CURRENT_PROJ_DIR` as `$PROJECTS_DIR/$site` with no context path, so clones always landed in the root projects directory
- Add `-c`/`--context` flag mirroring `site add`
- When `BUTLER_REQUIRED_CONTEXT=true` and no `-c` given, prompt for context (same behaviour as `site add`)
- Context must be alphabetic (same validation as `site add`)
- 3 new tests covering context clone path, non-alphabetic context rejection, and no-context root clone

## Test plan

- [ ] `butler site clone -c personal mysite <repo>` clones into `$PROJECTS_DIR/personal/mysite`
- [ ] `butler site clone mysite <repo>` (no context) clones into `$PROJECTS_DIR/mysite`
- [ ] `butler site clone -c "bad-ctx" mysite <repo>` exits with error
- [ ] With `BUTLER_REQUIRED_CONTEXT=true`, omitting `-c` prompts for a context
- [ ] `just test` passes (94 tests)