### PR TITLE
fix(autocomplete): replace mapfile with zsh-compatible COMPREPLY assignment

### DIFF
--- a/bin/autocomplete
+++ b/bin/autocomplete
@@ -21,16 +21,20 @@ _butler_autocomplete() {
   2)
     case ${cur} in
     up | down | restart)
-      mapfile -t COMPREPLY < <(compgen -W "$(ls "$BUTLER_SITES_DIR"/)")
+      # shellcheck disable=SC2207
+      COMPREPLY=($(compgen -W "$(ls "$BUTLER_SITES_DIR"/)"))
       ;;
     php | exec)
-      mapfile -t COMPREPLY < <(compgen -f -- "${COMP_WORDS[COMP_CWORD]}")
+      # shellcheck disable=SC2207
+      COMPREPLY=($(compgen -f -- "${COMP_WORDS[COMP_CWORD]}"))
       ;;
     sftp)
-      mapfile -t COMPREPLY < <(compgen -W "-k --key -u --upload -p --port -P --password -h --help" -- "${COMP_WORDS[COMP_CWORD]}")
+      # shellcheck disable=SC2207
+      COMPREPLY=($(compgen -W "-k --key -u --upload -p --port -P --password -h --help" -- "${COMP_WORDS[COMP_CWORD]}"))
       ;;
     ftp)
-      mapfile -t COMPREPLY < <(compgen -W "-u --upload -p --port -P --password -h --help" -- "${COMP_WORDS[COMP_CWORD]}")
+      # shellcheck disable=SC2207
+      COMPREPLY=($(compgen -W "-u --upload -p --port -P --password -h --help" -- "${COMP_WORDS[COMP_CWORD]}"))
       ;;
     esac
     ;;
@@ -39,14 +43,16 @@ _butler_autocomplete() {
     site)
       case ${cur} in
       cd)
-        mapfile -t COMPREPLY < <(compgen -W "$(ls "$BUTLER_SITES_DIR"/)")
+        # shellcheck disable=SC2207
+        COMPREPLY=($(compgen -W "$(ls "$BUTLER_SITES_DIR"/)"))
         ;;
       esac
       ;;
     sftp)
       case ${COMP_WORDS[COMP_CWORD - 1]} in
       -k | --key | -u | --upload)
-        mapfile -t COMPREPLY < <(compgen -f -- "${COMP_WORDS[COMP_CWORD]}")
+        # shellcheck disable=SC2207
+        COMPREPLY=($(compgen -f -- "${COMP_WORDS[COMP_CWORD]}"))
         ;;
       esac
       ;;


### PR DESCRIPTION
## Summary

- `mapfile` is a bash 4 builtin — not available in zsh
- The autocomplete script is sourced by zsh's bash-completion layer, so `mapfile` caused `zsh: command not found: mapfile` on every tab press
- Revert to the original `COMPREPLY=($(compgen ...))` form (which was correct) and add `# shellcheck disable=SC2207` inline — word splitting on completion results is intentional

## Test plan

- [ ] Tab-complete `butler up <TAB>` in zsh — lists sites without error
- [ ] Tab-complete `butler site cd <TAB>` in zsh — lists sites
- [ ] `just lint` passes clean