### PR TITLE
feat(autocomplete): add command completion and self-updating site subcommands

### DIFF
--- a/bin/_complete
+++ b/bin/_complete
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Internal completion handler — called by bin/autocomplete
+
+BUTLER_COMMANDS="up down restart exec php exect shell composer run proxy docker-compose dns templates ftp sftp mysql site"
+
+_list_sites() {
+  [ -d "$SITES_DIR" ] || return
+  # shellcheck disable=SC2012
+  ls "$SITES_DIR"/
+}
+
+_list_site_commands() {
+  # Derived from bin/site-* so new subcommands are picked up automatically
+  # shellcheck disable=SC2012
+  ls "$BIN_DIR"/site-* 2>/dev/null | sed 's|.*/site-||'
+}
+
+main() {
+  local cword="${1:-1}"
+  shift
+  local cmd="${2:-}" # COMP_WORDS[1]
+  local sub="${3:-}" # COMP_WORDS[2]
+
+  case "$cword" in
+  1)
+    echo "$BUTLER_COMMANDS"
+    ;;
+  2)
+    case "$cmd" in
+    up | down | restart | exec | php | exect | shell | composer | run | proxy | docker-compose)
+      _list_sites
+      ;;
+    site)
+      _list_site_commands
+      ;;
+    sftp)
+      echo "-k --key -u --upload -p --port -P --password -h --help"
+      ;;
+    ftp)
+      echo "-u --upload -p --port -P --password -h --help"
+      ;;
+    esac
+    ;;
+  3)
+    case "$cmd" in
+    site)
+      case "$sub" in
+      cd | status | link | clone | convert)
+        _list_sites
+        ;;
+      esac
+      ;;
+    esac
+    ;;
+  esac
+  exit 0
+}
+
+main "$@"

--- a/bin/autocomplete
+++ b/bin/autocomplete
@@ -10,58 +10,25 @@ set +a
 
 _butler_autocomplete() {
   local cur prev
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  prev="${COMP_WORDS[COMP_CWORD - 1]}"
 
-  cur=${COMP_WORDS[COMP_CWORD - 1]}
-  prev=${COMP_WORDS[COMP_CWORD - 2]}
-
-  case ${COMP_CWORD} in
-  1)
-    COMPREPLY=()
-    ;;
-  2)
-    case ${cur} in
-    up | down | restart)
-      # shellcheck disable=SC2207
-      COMPREPLY=($(compgen -W "$(ls "$BUTLER_SITES_DIR"/)"))
-      ;;
-    php | exec)
-      # shellcheck disable=SC2207
-      COMPREPLY=($(compgen -f -- "${COMP_WORDS[COMP_CWORD]}"))
-      ;;
-    sftp)
-      # shellcheck disable=SC2207
-      COMPREPLY=($(compgen -W "-k --key -u --upload -p --port -P --password -h --help" -- "${COMP_WORDS[COMP_CWORD]}"))
-      ;;
-    ftp)
-      # shellcheck disable=SC2207
-      COMPREPLY=($(compgen -W "-u --upload -p --port -P --password -h --help" -- "${COMP_WORDS[COMP_CWORD]}"))
-      ;;
-    esac
-    ;;
-  3)
-    case ${prev} in
-    site)
-      case ${cur} in
-      cd)
-        # shellcheck disable=SC2207
-        COMPREPLY=($(compgen -W "$(ls "$BUTLER_SITES_DIR"/)"))
-        ;;
-      esac
-      ;;
-    sftp)
-      case ${COMP_WORDS[COMP_CWORD - 1]} in
-      -k | --key | -u | --upload)
-        # shellcheck disable=SC2207
-        COMPREPLY=($(compgen -f -- "${COMP_WORDS[COMP_CWORD]}"))
-        ;;
-      esac
-      ;;
-    esac
-    ;;
-  *)
-    COMPREPLY=()
+  # File completion for commands that take a path argument
+  case "$prev" in
+  php | exec)
+    # shellcheck disable=SC2207
+    COMPREPLY=($(compgen -f -- "$cur"))
+    return
     ;;
   esac
+  if [[ "${COMP_WORDS[1]}" == "sftp" ]] && [[ "$prev" == "-k" || "$prev" == "--key" || "$prev" == "-u" || "$prev" == "--upload" ]]; then
+    # shellcheck disable=SC2207
+    COMPREPLY=($(compgen -f -- "$cur"))
+    return
+  fi
+
+  # shellcheck disable=SC2207
+  COMPREPLY=($(compgen -W "$(butler _complete "$COMP_CWORD" "${COMP_WORDS[@]}")" -- "$cur"))
 }
 
 complete -F _butler_autocomplete butler

--- a/butler
+++ b/butler
@@ -73,7 +73,7 @@ export HOST_GID
 
 # Non-site-aware commands skip site resolution; everything else resolves
 case $function in
-site | ftp | sftp | mysql | dns | templates) ;;
+site | ftp | sftp | mysql | dns | templates | _complete) ;;
 *) resolve_site "$1" && shift ;;
 esac
 
@@ -106,6 +106,7 @@ case $function in
 'ftp') . "$BIN_DIR/ftp" "$@" ;;
 'sftp') . "$BIN_DIR/sftp" "$@" ;;
 'mysql') . "$BIN_DIR/mysql" "$@" ;;
+'_complete') . "$BIN_DIR/_complete" "$@" ;;
 
 *)
   print_usage


### PR DESCRIPTION
## Summary

- `butler <TAB>` now lists all top-level commands
- `butler site <TAB>` lists site subcommands — derived from `bin/site-*` filenames so new subcommands appear automatically without touching the autocomplete script
- `butler up <TAB>`, `butler down <TAB>` etc. complete site names from `$SITES_DIR`
- `butler site cd <TAB>`, `butler site clone <TAB>` etc. complete site names

Introduces `bin/_complete` as an internal handler (`butler _complete $COMP_CWORD "${COMP_WORDS[@]}"`) so completion logic lives alongside the commands. The `bin/autocomplete` script becomes a thin wrapper delegating to it.

When adding a new site subcommand (`bin/site-foo`), tab completion picks it up automatically. When adding a new top-level command, update `BUTLER_COMMANDS` in `bin/_complete` — one line in one file.

## Test plan

- [ ] `butler <TAB>` → shows `up down restart exec php ...`
- [ ] `butler site <TAB>` → shows `add list clone cd convert status link`
- [ ] `butler up <TAB>` → shows site names
- [ ] `butler site cd <TAB>` → shows site names
- [ ] `just lint` passes clean