### PR TITLE
chore(todo): remove completed and stale items

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,13 +5,7 @@
 - Remove extra scripts checks from docker-compose passthrough which is only relavent to "up"
 - Add custom commands to Sites/ e.g. "butler artisan" which can be aliased to butler run php /app/artisan
 - Add laravel, currently have a laravel script to run the build url
-- source env file in makefile
-    It worked for me because I have run butler, butler exports the env vars
-    We should probably prefix the env vars when we export them so that they don't clash
-    We can then move that exporting to a new common bin and execute that before running the make file
-    We can exit with an error if the env file does not exist, or run a setup
 - auto create networks
 - I wonder if there could be some kinda watcher on domains so if you
   browse to example.local and a site exists for that domain it boots it
 - When running exec on a container ensure container is up first
-- Tidy up site fix etc. as they use common functions, pull these out


### PR DESCRIPTION
- Remove makefile env sourcing item (not relevant — justfile recipes don't need butler env vars)
- Remove site-fix tidy up item (done — common functions extracted to functions.sh)