### PR TITLE
feat(templates)!: consolidate to single butler network

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,7 @@
 - Remove extra scripts checks from docker-compose passthrough which is only relavent to "up"
 - Add custom commands to Sites/ e.g. "butler artisan" which can be aliased to butler run php /app/artisan
 - Add laravel, currently have a laravel script to run the build url
-- auto create networks
+- Move from mailhog to mailtrap
 - I wonder if there could be some kinda watcher on domains so if you
   browse to example.local and a site exists for that domain it boots it
 - When running exec on a container ensure container is up first

--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -22,6 +22,9 @@ shift
 # Ensure we are not in a docker directory as this breaks --project-directory
 cd "$BIN_DIR" || exit
 
+# Ensure butler network exists
+docker network create butler 2>/dev/null || true
+
 # Ensure nginx-proxy is up
 docker ps | grep -q nginx-proxy || docker compose \
   --project-directory "$ROOT_DIR/common/nginx-proxy" up -d

--- a/common/mailhog/docker-compose.yml
+++ b/common/mailhog/docker-compose.yml
@@ -6,9 +6,8 @@ services:
       - 8025:8025
       - 1025:1025
     networks:
-      - mailhog
+      - default
 networks:
-  mailhog:
+  default:
     external: true
-    name: mailhog
-
+    name: butler

--- a/common/mysql/docker-compose.yml
+++ b/common/mysql/docker-compose.yml
@@ -10,12 +10,11 @@ services:
     ports:
       - 3306:3306
     networks:
-      - mysql
-    command:  --sql_mode="NO_ENGINE_SUBSTITUTION"
+      - default
+    command: --sql_mode="NO_ENGINE_SUBSTITUTION"
 volumes:
-    mysqldata: {}
+  mysqldata: {}
 networks:
-  mysql:
+  default:
     external: true
-    name: mysql
-
+    name: butler

--- a/common/nginx-proxy/docker-compose.yml
+++ b/common/nginx-proxy/docker-compose.yml
@@ -11,4 +11,4 @@ services:
 networks:
   default:
     external: true
-    name: nginx-proxy
+    name: butler

--- a/templates/commerce-5.6/docker-compose.yml
+++ b/templates/commerce-5.6/docker-compose.yml
@@ -18,20 +18,12 @@ services:
       APACHE_COMMERCE_DOCUMENT_ROOT: /var/www/html/shared/lib/commerce/public
     networks:
       - default
-      - mysql
-      - mailhog
     secrets:
       - user_ssh
 networks:
-  mailhog:
-    external: true
-    name: mailhog
-  mysql:
-    external: true
-    name: mysql
   default:
     external: true
-    name: nginx-proxy
+    name: butler
 secrets:
   user_ssh:
     file: ~/.ssh

--- a/templates/commerce/docker-compose.yml
+++ b/templates/commerce/docker-compose.yml
@@ -18,20 +18,12 @@ services:
       APACHE_COMMERCE_DOCUMENT_ROOT: /var/www/html/shared/lib/commerce/public
     networks:
       - default
-      - mysql
-      - mailhog
     secrets:
       - user_ssh
 networks:
-  mailhog:
-    external: true
-    name: mailhog
-  mysql:
-    external: true
-    name: mysql
   default:
     external: true
-    name: nginx-proxy
+    name: butler
 secrets:
   user_ssh:
     file: ~/.ssh

--- a/templates/engine/docker-compose.yml
+++ b/templates/engine/docker-compose.yml
@@ -16,20 +16,12 @@ services:
       APACHE_DOCUMENT_ROOT: /var/www/html/public
     networks:
       - default
-      - mysql
-      - mailhog
     secrets:
       - user_ssh
 networks:
-  mailhog:
-    external: true
-    name: mailhog
-  mysql:
-    external: true
-    name: mysql
   default:
     external: true
-    name: nginx-proxy
+    name: butler
 secrets:
   user_ssh:
     file: ~/.ssh

--- a/templates/php5.4-apache/docker-compose.yml
+++ b/templates/php5.4-apache/docker-compose.yml
@@ -18,7 +18,7 @@ services:
 networks:
   default:
     external: true
-    name: nginx-proxy
+    name: butler
 secrets:
   user_ssh:
     file: ~/.ssh

--- a/templates/php7.1-nginx/docker-compose.yml
+++ b/templates/php7.1-nginx/docker-compose.yml
@@ -18,17 +18,13 @@ services:
     volumes:
       - ./app:/app
     networks:
-      - mysql
       - default
     secrets:
       - user_ssh
 networks:
-  mysql:
-    external: true
-    name: mysql
   default:
     external: true
-    name: nginx-proxy
+    name: butler
 secrets:
   user_ssh:
     file: ~/.ssh

--- a/templates/php7.2-apache/docker-compose.yml
+++ b/templates/php7.2-apache/docker-compose.yml
@@ -19,7 +19,7 @@ services:
 networks:
   default:
     external: true
-    name: nginx-proxy
+    name: butler
 secrets:
   user_ssh:
     file: ~/.ssh

--- a/templates/php7.2-nginx/docker-compose.yml
+++ b/templates/php7.2-nginx/docker-compose.yml
@@ -18,17 +18,13 @@ services:
     volumes:
       - ./app:/app
     networks:
-      - mysql
       - default
     secrets:
       - user_ssh
 networks:
-  mysql:
-    external: true
-    name: mysql
   default:
     external: true
-    name: nginx-proxy
+    name: butler
 secrets:
   user_ssh:
     file: ~/.ssh

--- a/templates/php7.4-apache/docker-compose.yml
+++ b/templates/php7.4-apache/docker-compose.yml
@@ -19,7 +19,7 @@ services:
 networks:
   default:
     external: true
-    name: nginx-proxy
+    name: butler
 secrets:
   user_ssh:
     file: ~/.ssh

--- a/templates/php8.0-nginx/docker-compose.yml
+++ b/templates/php8.0-nginx/docker-compose.yml
@@ -18,17 +18,13 @@ services:
     volumes:
       - ./app:/app
     networks:
-      - mysql
       - default
     secrets:
       - user_ssh
 networks:
-  mysql:
-    external: true
-    name: mysql
   default:
     external: true
-    name: nginx-proxy
+    name: butler
 secrets:
   user_ssh:
     file: ~/.ssh

--- a/templates/php8.3-apache/docker-compose.yml
+++ b/templates/php8.3-apache/docker-compose.yml
@@ -16,20 +16,12 @@ services:
       APACHE_DOCUMENT_ROOT: /var/www/html/public
     networks:
       - default
-      - mysql
-      - mailhog
     secrets:
       - user_ssh
 networks:
-  mailhog:
-    external: true
-    name: mailhog
-  mysql:
-    external: true
-    name: mysql
   default:
     external: true
-    name: nginx-proxy
+    name: butler
 secrets:
   user_ssh:
     file: ~/.ssh

--- a/templates/php8.3/docker-compose.yml
+++ b/templates/php8.3/docker-compose.yml
@@ -10,17 +10,13 @@ services:
     extra_hosts:
       - host.docker.internal:host-gateway
     networks:
-      - mysql
-      - mailhog
+      - default
     secrets:
       - user_ssh
 networks:
-  mailhog:
+  default:
     external: true
-    name: mailhog
-  mysql:
-    external: true
-    name: mysql
+    name: butler
 secrets:
   user_ssh:
     file: ~/.ssh

--- a/templates/wordpress/docker-compose.yml
+++ b/templates/wordpress/docker-compose.yml
@@ -12,15 +12,7 @@ services:
       XDEBUG_CONFIG: start_with_request=yes discover_client_host=1 log_level=0
     networks:
       - default
-      - mysql
-      - mailhog
 networks:
-  mysql:
-    external: true
-    name: mysql
   default:
     external: true
-    name: nginx-proxy
-  mailhog:
-    external: true
-    name: mailhog
+    name: butler


### PR DESCRIPTION
Replaces the separate `nginx-proxy`, `mysql`, and `mailhog` external networks with a single `butler` network.

- All templates and shared service compose files updated to use `butler` network
- `bin/docker-compose` auto-creates the `butler` network on first run — no manual setup needed

**Breaking change:** existing sites must update their `docker-compose.yml` to use the `butler` network. The butler update and sites repo update must be deployed together.