### PR TITLE
fix(docker-compose): check site is resolved before app symlink pre-flight

### DIFF
--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -29,6 +29,9 @@ docker network create butler 2>/dev/null || true
 docker ps | grep -q nginx-proxy || docker compose \
   --project-directory "$ROOT_DIR/common/nginx-proxy" up -d
 
+# Ensure a site has been resolved before running any pre-flight checks
+[ -d "$CURRENT_SITE_DIR" ] || die_with_error "No site resolved. Specify a site name or run from within a project directory."
+
 # Ensure app symlink(s) are valid before attempting compose commands
 BUTLER_PROJECTS=""
 [ -f "$CURRENT_SITE_DIR/.env" ] && . "$CURRENT_SITE_DIR/.env"


### PR DESCRIPTION
Running `butler exec --help` (or any docker-compose command) outside a known project gave a misleading `app symlink is missing` error.

Added a `[ -d "$CURRENT_SITE_DIR" ]` guard before `assert_app_linked` so an unresolved site surfaces a clear message instead.