### PR TITLE
feat: add domain watcher to auto-boot sites on browse

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,14 @@ Without DNS configured, add entries to `/etc/hosts` manually:
 127.0.0.1 mysite.test
 ```
 
+## Domain Watcher
+
+Butler includes a watcher service that boots a site automatically when you browse to its `.test` domain — no need to `butler up` first.
+
+When nginx-proxy receives a request for a domain with no running container, it falls through to the watcher. The watcher reads the `Host` header, maps it to a site directory in `BUTLER_SITES_DIR`, runs `docker compose up -d` in the background, and returns a page that auto-refreshes in five seconds once the stack is ready.
+
+The watcher starts automatically alongside nginx-proxy the first time you run any docker-compose command.
+
 ## Two-Directory Model
 
 Butler maintains two separate directory trees:

--- a/TODO.md
+++ b/TODO.md
@@ -6,5 +6,3 @@
 - Add custom commands to Sites/ e.g. "butler artisan" which can be aliased to butler run php /app/artisan
 - Add laravel, currently have a laravel script to run the build url
 - Move from mailhog to mailtrap
-- I wonder if there could be some kinda watcher on domains so if you
-  browse to example.local and a site exists for that domain it boots it

--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -29,6 +29,10 @@ docker network create butler 2>/dev/null || true
 docker ps | grep -q nginx-proxy || docker compose \
   --project-directory "$ROOT_DIR/common/nginx-proxy" up -d
 
+# Ensure watcher is up
+docker ps | grep -q butler-watcher || docker compose \
+  --project-directory "$ROOT_DIR/common/watcher" up -d --build
+
 # Ensure a site has been resolved before running any pre-flight checks
 [ -d "$CURRENT_SITE_DIR" ] || die_with_error "No site resolved. Specify a site name or run from within a project directory."
 

--- a/common/nginx-proxy/docker-compose.yml
+++ b/common/nginx-proxy/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - ./proxy.conf:/etc/nginx/proxy.conf:ro
+    environment:
+      DEFAULT_HOST: butler-watcher
 
 networks:
   default:

--- a/common/nginx-proxy/proxy.conf
+++ b/common/nginx-proxy/proxy.conf
@@ -1,3 +1,17 @@
+# HTTP 1.1 support
+proxy_http_version 1.1;
+proxy_set_header Host $host$host_port;
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header Connection $proxy_connection;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Host $proxy_x_forwarded_host;
+proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
+proxy_set_header X-Forwarded-Ssl $proxy_x_forwarded_ssl;
+proxy_set_header X-Forwarded-Port $proxy_x_forwarded_port;
+proxy_set_header X-Original-URI $request_uri;
+proxy_set_header Proxy "";
+
 proxy_read_timeout 300;
 proxy_connect_timeout 300;
 proxy_send_timeout 300;

--- a/common/watcher/Dockerfile
+++ b/common/watcher/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3-alpine
+RUN apk add --no-cache docker-cli docker-cli-compose
+WORKDIR /app
+COPY watcher.py style.css ./
+CMD ["python3", "watcher.py"]

--- a/common/watcher/docker-compose.yml
+++ b/common/watcher/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  butler-watcher:
+    build: .
+    container_name: butler-watcher
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ${BUTLER_SITES_DIR}:${BUTLER_SITES_DIR}:ro
+    environment:
+      VIRTUAL_HOST: butler-watcher
+      BUTLER_SITES_DIR: ${BUTLER_SITES_DIR}
+      BUTLER_TLD: ${BUTLER_TLD:-test}
+
+networks:
+  default:
+    external: true
+    name: butler

--- a/common/watcher/style.css
+++ b/common/watcher/style.css
@@ -1,0 +1,46 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  background: #f5f5f5;
+}
+
+.centered {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+}
+
+.box {
+  padding: 2rem;
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.box.centered-content {
+  text-align: center;
+}
+
+.box.wide {
+  max-width: 800px;
+  margin: 4rem auto;
+}
+
+p {
+  color: #666;
+}
+
+h2.error {
+  color: #c0392b;
+  margin-top: 0;
+}
+
+pre {
+  background: #f8f8f8;
+  padding: 1rem;
+  border-radius: 4px;
+  overflow: auto;
+  font-size: 0.85em;
+  white-space: pre-wrap;
+}

--- a/common/watcher/watcher.py
+++ b/common/watcher/watcher.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+import http.server
+import os
+import socketserver
+import subprocess
+import tempfile
+import time
+
+SITES_DIR = os.environ.get('BUTLER_SITES_DIR', '/sites')
+TLD = os.environ.get('BUTLER_TLD', 'test')
+POLL_SECS = 0.5
+APP_DIR = os.path.dirname(__file__)
+
+
+def parse_dotenv(path):
+    env = {}
+    try:
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith('#') or '=' not in line:
+                    continue
+                key, _, val = line.partition('=')
+                env[key.strip()] = val.strip().strip('"').strip("'")
+    except OSError:
+        pass
+    return env
+
+
+def find_site(subdomain):
+    """Return (site_dir, site_name), preferring multi-project explicit matches."""
+    try:
+        entries = sorted(os.listdir(SITES_DIR))
+    except OSError:
+        return None, None
+
+    # Pass 1: explicit/auto-derived BUTLER_PROJECT_* in multi-project sites.
+    # A combined stack can serve multiple subdomains; match any of them here
+    # before falling back to a direct site directory name match.
+    for name in entries:
+        site_dir = os.path.join(SITES_DIR, name)
+        if not os.path.isdir(site_dir):
+            continue
+        env = parse_dotenv(os.path.join(site_dir, '.env'))
+        projects_raw = env.get('BUTLER_PROJECTS', '')
+        if not projects_raw:
+            continue
+        for proj in (p.strip() for p in projects_raw.split(',') if p.strip()):
+            key = 'BUTLER_PROJECT_' + proj.upper().replace('-', '_')
+            if env.get(key, proj) == subdomain:
+                return site_dir, name
+
+    # Pass 2: direct site directory name match.
+    site_dir = os.path.join(SITES_DIR, subdomain)
+    if os.path.isdir(site_dir):
+        return site_dir, subdomain
+
+    return None, None
+
+
+def build_env(site_dir, site_name):
+    env = os.environ.copy()
+    env['BUTLER_PROJECT'] = site_name
+    site_env = parse_dotenv(os.path.join(site_dir, '.env'))
+    env.update(site_env)
+    for proj in (p.strip() for p in site_env.get('BUTLER_PROJECTS', '').split(',') if p.strip()):
+        key = 'BUTLER_PROJECT_' + proj.upper().replace('-', '_')
+        env.setdefault(key, proj)
+    return env
+
+
+def page(title, head, body_class, content):
+    return f'''<!DOCTYPE html>
+<html>
+<head>
+  <title>{title}</title>
+  <link rel="stylesheet" href="/style.css">
+  {head}
+</head>
+<body class="{body_class}">
+  {content}
+</body>
+</html>'''.encode()
+
+
+class WatcherHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == '/style.css':
+            self._serve_static('style.css', 'text/css')
+            return
+
+        # nginx-proxy rewrites Host to its VIRTUAL_HOST value; original is in X-Forwarded-Host
+        host = (self.headers.get('X-Forwarded-Host') or self.headers.get('Host', '')).split(':')[0]
+        suffix = f'.{TLD}'
+        if not host.endswith(suffix):
+            self._respond_not_found(host)
+            return
+
+        subdomain = host[: -len(suffix)]
+        site_dir, site_name = find_site(subdomain)
+
+        if not site_dir:
+            self._respond_not_found(host)
+            return
+
+        env = build_env(site_dir, site_name)
+
+        with tempfile.TemporaryFile() as err_f:
+            proc = subprocess.Popen(
+                ['docker', 'compose', '--project-directory', site_dir, 'up', '-d'],
+                stdout=subprocess.DEVNULL,
+                stderr=err_f,
+                env=env,
+            )
+            time.sleep(POLL_SECS)
+            rc = proc.poll()
+            if rc is not None and rc != 0:
+                err_f.seek(0)
+                detail = err_f.read(4096).decode(errors='replace')
+                self._respond_error(site_name, detail)
+                return
+
+        self._respond_starting(site_name)
+
+    def _serve_static(self, filename, content_type):
+        try:
+            with open(os.path.join(APP_DIR, filename), 'rb') as f:
+                body = f.read()
+            self.send_response(200)
+            self.send_header('Content-Type', content_type)
+            self.send_header('Content-Length', len(body))
+            self.end_headers()
+            self.wfile.write(body)
+        except OSError:
+            self.send_response(404)
+            self.end_headers()
+
+    def _respond_starting(self, site):
+        body = page(
+            f'Starting {site}...',
+            '<meta http-equiv="refresh" content="5">',
+            'centered',
+            f'<div class="box centered-content"><h2>Starting {site}&hellip;</h2>'
+            f'<p>This page will refresh automatically.</p></div>',
+        )
+        self._send(200, body)
+
+    def _respond_error(self, site, detail=''):
+        detail_html = f'<pre>{detail}</pre>' if detail else ''
+        body = page(
+            f'Failed to start {site}',
+            '',
+            '',
+            f'<div class="box wide"><h2 class="error">Failed to start {site}</h2>'
+            f'{detail_html}'
+            f'<p>Run <code>butler up {site}</code> for more detail.</p></div>',
+        )
+        self._send(500, body)
+
+    def _respond_not_found(self, host):
+        body = page(
+            f'No site for {host}',
+            '',
+            'centered',
+            f'<div class="box centered-content"><h2>No site for {host}</h2>'
+            f'<p>Run <code>butler site add</code> to create one.</p></div>',
+        )
+        self._send(404, body)
+
+    def _send(self, status, body):
+        self.send_response(status)
+        self.send_header('Content-Type', 'text/html')
+        self.send_header('Content-Length', len(body))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, fmt, *args):
+        pass
+
+
+class ThreadedWatcher(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    daemon_threads = True
+
+
+if __name__ == '__main__':
+    print(f'Butler watcher running — SITES_DIR={SITES_DIR} TLD={TLD}', flush=True)
+    ThreadedWatcher(('', 80), WatcherHandler).serve_forever()


### PR DESCRIPTION
## Summary

- Adds `common/watcher/` — a small Python HTTP server that receives unmatched nginx-proxy requests via `DEFAULT_HOST`, looks up the site in `BUTLER_SITES_DIR`, runs `docker compose up -d`, and returns a 5-second meta-refresh page
- Multi-project sites are supported: subdomains belonging to a combined stack are resolved via `BUTLER_PROJECT_*` mappings in the site's `.env`
- Failure detection shows an error page with compose output if the stack fails to start
- Sets `DEFAULT_HOST: butler-watcher` in `common/nginx-proxy/docker-compose.yml`
- Restores missing `proxy_set_header` directives in `proxy.conf`, fixing header forwarding for all backends
- `bin/docker-compose` starts the watcher alongside nginx-proxy on first use