### PR TITLE
docs: note PHP focus in README, tidy TODO

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Butler
 
-**Your friendly dev stack helper** — a bash CLI that wraps Docker Compose to manage local development stacks. Runs nginx-proxy as a shared reverse-proxy so multiple sites can be served under `.test` domains simultaneously.
+**Your friendly PHP dev stack helper** — a bash CLI that wraps Docker Compose to manage local PHP development stacks. Runs nginx-proxy as a shared reverse-proxy so multiple sites can be served under `.test` domains simultaneously. Templates, presets, and built-in commands are PHP-oriented; other stacks can be managed but are not first-class.
 
 ## Prerequisites
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,9 +2,7 @@
 
 - add ability to use in project docker compose as well - fall back to docker-composer commands like the laravel one?
 - Look at laravels one as it might help tidy up the code
-- Rename site pre-hook directory from scripts/ to hooks/ to distinguish lifecycle hooks from user-facing site commands
-- Add butler.toml for static site config (preset, required services etc.) — TOML over YAML for readability. Presets (laravel, wordpress etc.) unlock built-in CLI commands for that stack. Required services replace the current scripts/up pattern for starting shared services
 - Add site script discoverability: a command to list scripts available for the current site, and auto-expose them as butler commands — guarded against clashes with built-in commands
-- Note PHP focus in README
-- Add laravel, currently have a laravel script to run the build url
+- Add butler.toml for static site config (preset, required services etc.) — TOML over YAML for readability. Presets (laravel, wordpress etc.) unlock built-in CLI commands for that stack. Required services would start shared services automatically, replacing manual hooks/up scripts
+- Add laravel preset (blocked by script discoverability and butler.toml)
 - Move from mailhog to mailtrap


### PR DESCRIPTION
## Summary

Notes PHP focus in the README introduction and tidies the TODO to remove completed items and clarify the ordering dependency between script discoverability, butler.toml, and the Laravel preset.