### PR TITLE
feat!: replace mailhog with mailpit

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,7 @@
 # Butler TODO
 
-- add ability to use in project docker compose as well - fall back to docker-composer commands like the laravel one?
-- Look at laravels one as it might help tidy up the code
 - Add site script discoverability: a command to list scripts available for the current site, and auto-expose them as butler commands — guarded against clashes with built-in commands
 - Add butler.toml for static site config (preset, required services etc.) — TOML over YAML for readability. Presets (laravel, wordpress etc.) unlock built-in CLI commands for that stack. Required services would start shared services automatically, replacing manual hooks/up scripts
 - Add laravel preset (blocked by script discoverability and butler.toml)
-- Move from mailhog to mailtrap
+- add ability to use in project docker compose as well - fall back to docker-composer commands like the laravel one?
+- Look at laravels one as it might help tidy up the code

--- a/common/mailpit/docker-compose.yml
+++ b/common/mailpit/docker-compose.yml
@@ -1,12 +1,11 @@
 services:
-  mailhog:
-    container_name: mailhog
-    image: mailhog/mailhog
+  mailpit:
+    container_name: mailpit
+    image: axllent/mailpit
     ports:
       - 8025:8025
       - 1025:1025
-    networks:
-      - default
+
 networks:
   default:
     external: true

--- a/templates/commerce-5.6/hooks/up
+++ b/templates/commerce-5.6/hooks/up
@@ -3,9 +3,9 @@
 DIR="$(dirname "$(readlink -f "$0")")"
 
 # Ensure mysql is up
-[ ! "$(docker ps | grep mysql_mysql_1)" ] && docker-compose \
+docker ps | grep -q mysql || docker compose \
     --project-directory "$DIR/common/mysql" up -d
 
-# Ensure mailhog is up
-[ ! "$(docker ps | grep mailhog_mailhog_1)" ] && docker-compose \
-    --project-directory "$DIR/common/mailhog" up -d
+# Ensure mailpit is up
+docker ps | grep -q mailpit || docker compose \
+    --project-directory "$DIR/common/mailpit" up -d

--- a/templates/commerce/hooks/up
+++ b/templates/commerce/hooks/up
@@ -3,9 +3,9 @@
 DIR="$(dirname "$(readlink -f "$0")")"
 
 # Ensure mysql is up
-[ ! "$(docker ps | grep mysql_mysql_1)" ] && docker-compose \
+docker ps | grep -q mysql || docker compose \
     --project-directory "$DIR/common/mysql" up -d
 
-# Ensure mailhog is up
-[ ! "$(docker ps | grep mailhog_mailhog_1)" ] && docker-compose \
-    --project-directory "$DIR/common/mailhog" up -d
+# Ensure mailpit is up
+docker ps | grep -q mailpit || docker compose \
+    --project-directory "$DIR/common/mailpit" up -d

--- a/templates/engine/hooks/up
+++ b/templates/engine/hooks/up
@@ -3,9 +3,9 @@
 DIR="$(dirname "$(readlink -f "$0")")"
 
 # Ensure mysql is up
-[ ! "$(docker ps | grep mysql_mysql_1)" ] && docker-compose \
+docker ps | grep -q mysql || docker compose \
     --project-directory "$DIR/common/mysql" up -d
 
-# Ensure mailhog is up
-[ ! "$(docker ps | grep mailhog_mailhog_1)" ] && docker-compose \
-    --project-directory "$DIR/common/mailhog" up -d
+# Ensure mailpit is up
+docker ps | grep -q mailpit || docker compose \
+    --project-directory "$DIR/common/mailpit" up -d

--- a/templates/wordpress/hooks/up
+++ b/templates/wordpress/hooks/up
@@ -3,9 +3,9 @@
 DIR="$(dirname "$(readlink -f "$0")")"
 
 # Ensure mysql is up
-[ ! "$(docker ps | grep mysql_mysql_1)" ] && docker-compose \
+docker ps | grep -q mysql || docker compose \
     --project-directory "$DIR/common/mysql" up -d
 
-# Ensure mailhog is up
-[ ! "$(docker ps | grep mailhog_mailhog_1)" ] && docker-compose \
-    --project-directory "$DIR/common/mailhog" up -d
+# Ensure mailpit is up
+docker ps | grep -q mailpit || docker compose \
+    --project-directory "$DIR/common/mailpit" up -d


### PR DESCRIPTION
## Summary

Replaces the mailhog mail catcher with [Mailpit](https://mailpit.axllent.org/). Same ports (SMTP 1025, web UI 8025).

BREAKING CHANGE: the SMTP hostname changes from `mailhog` to `mailpit`. Update application mail config accordingly.