### PR TITLE
refactor: tidy up site commands for v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ If `SITE` is omitted from site commands, butler infers the site from your curren
 
 | Command | Description |
 | --- | --- |
-| `butler install` | First-time setup wizard |
 | `butler site add` | Add a new site |
 | `butler site list` | List all sites |
 | `butler site clone [-c CONTEXT] [SITE] <REPO>` | Clone a repo and link it to an existing site |

--- a/bin/common/functions.sh
+++ b/bin/common/functions.sh
@@ -111,6 +111,20 @@ die_with_error() {
   exit 1
 }
 
+for_each_site() {
+  local callback="$1"
+  local found=false
+  local site site_dir
+  for site_dir in "$SITES_DIR"/*/; do
+    [ -d "$site_dir" ] || continue
+    site_dir="${site_dir%/}"
+    site="$(basename "$site_dir")"
+    found=true
+    "$callback" "$site" "$site_dir"
+  done
+  $found || echo "No sites found in $SITES_DIR"
+}
+
 dns_is_configured() {
   local tld="${BUTLER_TLD:-test}"
   local butler_conf

--- a/bin/site-add
+++ b/bin/site-add
@@ -125,7 +125,7 @@ main() {
 
   $BUTLER_REQUIRED_CONTEXT && [ -z "$context" ] && read -rp "Specify a context: " context
 
-  [[ ! "$context" =~ ^[[:alpha:]]*$ ]] && echo -e "${CError}Context must be alphabetic" && exit 1
+  [[ ! "$context" =~ ^[[:alnum:]_-]*$ ]] && echo -e "${CError}Context must be alphanumeric (hyphens and underscores allowed)" && exit 1
 
   if $multi; then
     # Multi-project: collect all input first, then execute

--- a/bin/site-link
+++ b/bin/site-link
@@ -125,25 +125,15 @@ link_site() {
   fi
 }
 
+_link_one() {
+  if ! link_site "$1" "$2" "$fix"; then
+    $verbose && statusBadge "$1" "SKIP" "$CWarn" "no project found"
+  fi
+}
+
 link_all() {
   local fix="$1" verbose="$2"
-  local site_dir site found=false
-
-  for site_dir in "$SITES_DIR"/*/; do
-    [ -d "$site_dir" ] || continue
-    site_dir="${site_dir%/}"
-    site="$(basename "$site_dir")"
-    found=true
-
-    if ! link_site "$site" "$site_dir" "$fix"; then
-      $verbose && statusBadge "$site" "SKIP" "$CWarn" "no project found"
-      continue
-    fi
-  done
-
-  if ! $found; then
-    echo "No sites found in $SITES_DIR"
-  fi
+  for_each_site _link_one
 }
 
 main() {

--- a/bin/site-list
+++ b/bin/site-list
@@ -3,6 +3,8 @@
 
 PACKAGE="butler site list"
 
+. "$COMMON_DIR/functions.sh"
+
 print_usage() {
   echo "List all sites"
   echo " "
@@ -11,19 +13,11 @@ print_usage() {
   echo "$PACKAGE"
 }
 
+_list_one() {
+  echo -e "  ${Green}$1${Color_Off}"
+}
+
 main() {
   [ "$1" = "-h" ] || [ "$1" = "--help" ] && print_usage && exit 0
-
-  local found=false
-  local site_dir
-
-  for site_dir in "$SITES_DIR"/*/; do
-    [ -d "$site_dir" ] || continue
-    echo -e "  ${Green}$(basename "$site_dir")${Color_Off}"
-    found=true
-  done
-
-  if ! $found; then
-    echo "No sites found in $SITES_DIR"
-  fi
+  for_each_site _list_one
 }

--- a/bin/site-status
+++ b/bin/site-status
@@ -23,8 +23,11 @@ status_single() {
   local status
   status="$(app_link_status "$app_path")"
 
+  local extra=""
+  $verbose && extra="[$site_dir]"
+
   case "$status" in
-  ok) statusBadge "$site" "OK" "$CSuccess" "${verbose:+[$site_dir]}" ;;
+  ok) statusBadge "$site" "OK" "$CSuccess" "$extra" ;;
   broken)
     local target
     target="$(readlink "$app_path")"
@@ -42,7 +45,9 @@ status_multi() {
   local site="$1" site_dir="$2" verbose="$3"
   local app_path="$site_dir/app"
 
-  echo -e "${site}${verbose:+ [$site_dir]}"
+  local site_label="$site"
+  $verbose && site_label="$site [$site_dir]"
+  echo -e "$site_label"
 
   local p status
   for p in ${BUTLER_PROJECTS//,/ }; do

--- a/bin/site-status
+++ b/bin/site-status
@@ -61,6 +61,21 @@ status_multi() {
   done
 }
 
+_status_one() {
+  local site="$1" site_dir="$2"
+  BUTLER_PROJECTS=""
+  [ -f "$site_dir/.env" ] && {
+    set -a
+    . "$site_dir/.env"
+    set +a
+  }
+  if [ -n "$BUTLER_PROJECTS" ]; then
+    status_multi "$site" "$site_dir" "$verbose"
+  else
+    status_single "$site" "$site_dir" "$verbose"
+  fi
+}
+
 main() {
   help=false
   verbose=false
@@ -85,7 +100,10 @@ main() {
 
   site="$1"
 
-  [ -z "$site" ] && echo -e "${CWarn}All sites is not yet implemented${Color_Off}" && exit 0
+  if [ -z "$site" ]; then
+    for_each_site _status_one
+    exit 0
+  fi
 
   if ! site_dir="$(get_site_dir "$site")"; then
     die_with_error "Site ${CWarn}$site${Color_Off} doesn't exist"

--- a/bin/site-status
+++ b/bin/site-status
@@ -109,17 +109,5 @@ main() {
     die_with_error "Site ${CWarn}$site${Color_Off} doesn't exist"
   fi
 
-  # Load site env to pick up BUTLER_PROJECTS if set
-  BUTLER_PROJECTS=""
-  if [ -f "$site_dir/.env" ]; then
-    set -a
-    . "$site_dir/.env"
-    set +a
-  fi
-
-  if [ -n "$BUTLER_PROJECTS" ]; then
-    status_multi "$site" "$site_dir" "$verbose"
-  else
-    status_single "$site" "$site_dir" "$verbose"
-  fi
+  _status_one "$site" "$site_dir"
 }

--- a/tests/unit/functions.bats
+++ b/tests/unit/functions.bats
@@ -55,6 +55,21 @@ load "../helpers/common"
   [ "$result" = "$base/templates/mytemplate" ]
 }
 
+@test "for_each_site calls callback for each site directory" {
+  mkdir -p "$SITES_DIR/alpha" "$SITES_DIR/beta"
+  _collect_site() { echo "site:$1"; }
+  result="$(for_each_site _collect_site)"
+  [[ "$result" == *"alpha"* ]]
+  [[ "$result" == *"beta"* ]]
+}
+
+@test "for_each_site prints message when no sites exist" {
+  _noop() { :; }
+  run for_each_site _noop
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No sites found"* ]]
+}
+
 @test "get_template_dir exits nonzero when template is absent" {
   local base
   base="$(mktemp -d)"

--- a/tests/unit/site-add.bats
+++ b/tests/unit/site-add.bats
@@ -23,8 +23,8 @@ setup_extra() {
   [ "$status" -eq 1 ]
 }
 
-@test "main exits 1 for non-alphabetic context" {
-  run main -t php8.3 -n mysite -c 1invalid -r /dev/null
+@test "main exits 1 for invalid context" {
+  run main -t php8.3 -n mysite -c "inv@lid!" -r /dev/null
   [ "$status" -eq 1 ]
 }
 

--- a/tests/unit/site-status.bats
+++ b/tests/unit/site-status.bats
@@ -83,6 +83,25 @@ setup_extra() {
   [[ "$output" == *"OK"* ]]
 }
 
+@test "main with no args shows status for all sites" {
+  local proj_dir site_dir
+  proj_dir="$(mktemp -d)"
+  site_dir="$SITES_DIR/mysite"
+  mkdir -p "$site_dir"
+  ln -s "$proj_dir" "$site_dir/app"
+
+  run main
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"mysite"* ]]
+  [[ "$output" == *"OK"* ]]
+}
+
+@test "main with no args prints message when no sites exist" {
+  run main
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No sites found"* ]]
+}
+
 @test "status_multi reports BROKEN for dead project symlink" {
   local proj_dir site_dir
   proj_dir="$(mktemp -d)"


### PR DESCRIPTION
- Extract `for_each_site` helper to consolidate duplicated site-loop logic across `site-list`, `site-link`, and `site-status`
- Implement `butler site status` with no args to list all sites
- Fix verbose flag in `site-status` so `-v` correctly gates directory display
- Remove non-existent `butler install` command from README
- Allow alphanumeric context names with hyphens and underscores in `site add`